### PR TITLE
Adding golanglint config

### DIFF
--- a/linkfiles/.golangci.yaml
+++ b/linkfiles/.golangci.yaml
@@ -1,0 +1,4 @@
+# Options for analysis running.
+run:
+  # Timeout for analysis, e.g. 30s, 5m.
+  timeout: 5m

--- a/tasks/golang/Makefile
+++ b/tasks/golang/Makefile
@@ -11,13 +11,14 @@ FIND ?= find
 # Variables
 
 GO_TEST_DIRECTORIES ?= tests
+GOLANGCI_LINT_CONFIG ?= .golangci.yaml
 
 # Functions
 
 # Checks for Go files in the GO_TEST_DIRECTORIES. If they exist, runs the default configuration for golangci-lint
 # https://golangci-lint.run/usage/quick-start/
 define go_lint
-	$(FIND) $(1)/ -name '*.go' | $(GREP) -q '\.go' || exit 0; $(GOLANGCI_LINT) run -v ./$(1)/...;
+	$(FIND) $(1)/ -name '*.go' | $(GREP) -q '\.go' || exit 0; $(GOLANGCI_LINT) run -c $(GOLANGCI_LINT_CONFIG) -v ./$(1)/...;
 
 endef
 


### PR DESCRIPTION
This keeps the initial `make configure` and `make check` not timeout and fail. Seems there is a cache with golintci where it runs much faster the first time, but this should cut done on first run questions or failures in demos

Associated PRs: https://github.com/nexient-llc/module-manifests/pull/3 https://github.com/nexient-llc/tf-module-skeleton/pull/8