### PR TITLE
make linting conditional for GitHub Actions

### DIFF
--- a/tasks/golang/Makefile
+++ b/tasks/golang/Makefile
@@ -16,13 +16,14 @@ DISABLE_MAKE_CHECK_LINT ?= true
 
 # Functions
 
-# Runs go vet and ignores errors when there are no Go files
+# Checks for Go files in the GO_TEST_DIRECTORIES. If they exist, runs the default configuration for golangci-lint
+# https://golangci-lint.run/usage/quick-start/
 define go_lint
 	$(FIND) $(1)/ -name '*.go' | $(GREP) -q '\.go' || exit 0; $(GOLANGCI_LINT) run -c $(GOLANGCI_LINT_CONFIG) -v ./$(1)/...;
 
 endef
 
-# Ensures the tests/ dir exists before running tests
+# Check for Go files. If they exist, run tests.
 define go_test
 	$(FIND) $(1)/ -name '*.go' | $(GREP) -q '\.go' || exit 0; $(GO) test -v ./$(1)/...;
 

--- a/tasks/golang/Makefile
+++ b/tasks/golang/Makefile
@@ -3,45 +3,48 @@ SHELL := /bin/bash
 # Binaries
 
 GO ?= go
-GOLANGCI_LINT ?= golangci-lint
 TEE ?= tee
 GREP ?= grep
-FIND ?= find
 
 # Variables
 
-GO_TEST_DIRECTORIES ?= tests
-GOLANGCI_LINT_CONFIG ?= .golangci.yaml
+GO_TEST_DIRECTORIES ?= tests/
 DISABLE_MAKE_CHECK_LINT ?= false
 
-# Linting
-ifeq ($(DISABLE_MAKE_CHECK_LINT),false)
-.PHONY: go/lint
-go/lint:
-	$(foreach test_dir,$(GO_TEST_DIRECTORIES),$(call go_lint,$(test_dir)))
+# Functions
 
-# Checks for Go files in the GO_TEST_DIRECTORIES. If they exist, runs the default configuration for golangci-lint
-# https://golangci-lint.run/usage/quick-start/
+# Runs go vet and ignores errors when there are no Go files
 define go_lint
-	$(FIND) $(1)/ -name '*.go' | $(GREP) -q '\.go' || exit 0; $(GOLANGCI_LINT) run -c $(GOLANGCI_LINT_CONFIG) -v ./$(1)/...;
+	OUTPUT=$$(set -o pipefail; $(GO) vet ./... 2>&1 | $(TEE) /dev/stdout); [ "$$?" = "0" ] || { echo $$OUTPUT | $(GREP) -q 'go mod init' || exit 1; }
 
 endef
 
-check:: go/lint
-endif
+# Ensures the tests/ dir exists before running tests
+define go_test
+	[ -d "$(1)" ] && $(GO) test -v ./$(1) || exit 0;
 
-# Testing
+endef
+
+# Tasks
+
+.PHONY: go/lint
+go/lint :
+	$(call go_lint)
+
 .PHONY: go/test
-go/test:
+go/test :
 	$(foreach test_dir,$(GO_TEST_DIRECTORIES),$(call go_test,$(test_dir)))
 
-# Check for Go files. If they exist, run tests.
-define go_test
-	$(FIND) $(1)/ -name '*.go' | $(GREP) -q '\.go' || exit 0; $(GO) test -v ./$(1)/...;
-
-endef
-
-# Check is dependent upon go/lint (optionally) and go/test
+# This is a special declaration
+# Whenever check is defined, it must be defined with a ::
+# _all_ check targets that are found will be run
+# https://www.gnu.org/software/make/manual/html_node/Double_002dColon.html
+# "check" is a GNU Make pattern that runs tests on configured software
 .PHONY: check
-check:: go/test
-	
+check::
+ifeq ($(DISABLE_MAKE_CHECK_LINT),false)
+	$(MAKE) go/lint
+else
+	$(info "make go/lint has been disabled!")
+endif
+	$(MAKE) go/test

--- a/tasks/golang/Makefile
+++ b/tasks/golang/Makefile
@@ -3,25 +3,28 @@ SHELL := /bin/bash
 # Binaries
 
 GO ?= go
+GOLANGCI_LINT ?= golangci-lint
 TEE ?= tee
 GREP ?= grep
+FIND ?= find
 
 # Variables
 
-GO_TEST_DIRECTORIES ?= tests/
-DISABLE_MAKE_CHECK_LINT ?= false
+GO_TEST_DIRECTORIES ?= tests
+GOLANGCI_LINT_CONFIG ?= .golangci.yaml
+DISABLE_MAKE_CHECK_LINT ?= true
 
 # Functions
 
 # Runs go vet and ignores errors when there are no Go files
 define go_lint
-	OUTPUT=$$(set -o pipefail; $(GO) vet ./... 2>&1 | $(TEE) /dev/stdout); [ "$$?" = "0" ] || { echo $$OUTPUT | $(GREP) -q 'go mod init' || exit 1; }
+	$(FIND) $(1)/ -name '*.go' | $(GREP) -q '\.go' || exit 0; $(GOLANGCI_LINT) run -c $(GOLANGCI_LINT_CONFIG) -v ./$(1)/...;
 
 endef
 
 # Ensures the tests/ dir exists before running tests
 define go_test
-	[ -d "$(1)" ] && $(GO) test -v ./$(1) || exit 0;
+	$(FIND) $(1)/ -name '*.go' | $(GREP) -q '\.go' || exit 0; $(GO) test -v ./$(1)/...;
 
 endef
 

--- a/tasks/golang/Makefile
+++ b/tasks/golang/Makefile
@@ -12,8 +12,13 @@ FIND ?= find
 
 GO_TEST_DIRECTORIES ?= tests
 GOLANGCI_LINT_CONFIG ?= .golangci.yaml
+DISABLE_MAKE_CHECK_LINT ?= false
 
-# Functions
+# Linting
+ifeq ($(DISABLE_MAKE_CHECK_LINT),false)
+.PHONY: go/lint
+go/lint:
+	$(foreach test_dir,$(GO_TEST_DIRECTORIES),$(call go_lint,$(test_dir)))
 
 # Checks for Go files in the GO_TEST_DIRECTORIES. If they exist, runs the default configuration for golangci-lint
 # https://golangci-lint.run/usage/quick-start/
@@ -22,23 +27,21 @@ define go_lint
 
 endef
 
+check:: go/lint
+endif
+
+# Testing
+.PHONY: go/test
+go/test:
+	$(foreach test_dir,$(GO_TEST_DIRECTORIES),$(call go_test,$(test_dir)))
+
 # Check for Go files. If they exist, run tests.
 define go_test
 	$(FIND) $(1)/ -name '*.go' | $(GREP) -q '\.go' || exit 0; $(GO) test -v ./$(1)/...;
 
 endef
 
-# Tasks
-
-.PHONY: go/lint
-go/lint:
-	$(foreach test_dir,$(GO_TEST_DIRECTORIES),$(call go_lint,$(test_dir)))
-
-.PHONY: go/test
-go/test:
-	$(foreach test_dir,$(GO_TEST_DIRECTORIES),$(call go_test,$(test_dir)))
-
+# Check is dependent upon go/lint (optionally) and go/test
 .PHONY: check
-check::
-	$(MAKE) go/lint
-	$(MAKE) go/test
+check:: go/test
+	


### PR DESCRIPTION
Place go/lint behind flag, defaulted to NOT disable, to prevent the GitHub action from running both the make and gha version of golangci-lint.